### PR TITLE
Fix LoggingMethodEntryProbe and LoggingMethodExitProbe

### DIFF
--- a/src/main/java/instrumentj/probes/impl/LoggingMethodEntryProbe.java
+++ b/src/main/java/instrumentj/probes/impl/LoggingMethodEntryProbe.java
@@ -15,11 +15,12 @@
  */
 package instrumentj.probes.impl;
 
+import instrumentj.probes.MethodEntryProbe;
 
 /**
  * @author Stephen Evanchik (evanchsa@gmail.com)
  */
-public class LoggingMethodEntryProbe extends BaseMethodProbe {
+public class LoggingMethodEntryProbe extends BaseMethodProbe implements MethodEntryProbe {
 
     @Override
     public void run(Object... args) {

--- a/src/main/java/instrumentj/probes/impl/LoggingMethodExitProbe.java
+++ b/src/main/java/instrumentj/probes/impl/LoggingMethodExitProbe.java
@@ -15,11 +15,12 @@
  */
 package instrumentj.probes.impl;
 
+import instrumentj.probes.MethodExitProbe;
 
 /**
  * @author Stephen Evanchik (evanchsa@gmail.com)
  */
-public class LoggingMethodExitProbe extends BaseMethodProbe {
+public class LoggingMethodExitProbe extends BaseMethodProbe implements MethodExitProbe {
 
     @Override
     public void run(Object... args) {


### PR DESCRIPTION
These classes didn't implement the respective method probe interfaces and, as such, weren't being detected at instrumentation-time.

By invoking the test application, the `Enter:` and `Exit:` outputs now appear:

```
Enter:main|test/instrumentj/impl/SomeClass|<init>|()V|[Ljava.lang.Object;@fb95de0
Stateful entering method: test/instrumentj/impl/SomeClass|<init>|()V
Exit:main|test/instrumentj/impl/SomeClass|<init>|()V|177
Stateful exiting method: test/instrumentj/impl/SomeClass|<init>|()V
Enter:main|test/instrumentj/impl/SomeClass|aMethod|()V|[Ljava.lang.Object;@634a988
Stateful entering method: test/instrumentj/impl/SomeClass|aMethod|()V
aMethod
Enter:main|test/instrumentj/impl/SomeClass|cMethod|()V|[Ljava.lang.Object;@6b6622e6
Stateful entering method: test/instrumentj/impl/SomeClass|cMethod|()V
cMethod
Exit:main|test/instrumentj/impl/SomeClass|cMethod|()V|177
Stateful exiting method: test/instrumentj/impl/SomeClass|cMethod|()V
Exit:main|test/instrumentj/impl/SomeClass|aMethod|()V|177
Stateful exiting method: test/instrumentj/impl/SomeClass|aMethod|()V
Enter:main|test/instrumentj/impl/SomeClass|bMethod|()V|[Ljava.lang.Object;@7e7d611f
Stateful entering method: test/instrumentj/impl/SomeClass|bMethod|()V
bMethod
Exit:main|test/instrumentj/impl/SomeClass|bMethod|()V|177
Stateful exiting method: test/instrumentj/impl/SomeClass|bMethod|()V
Enter:main|test/instrumentj/impl/SomeClass|dMethod|(Ljava/lang/String;I)V|[Ljava.lang.Object;@59737b19
Stateful entering method: test/instrumentj/impl/SomeClass|dMethod|(Ljava/lang/String;I)V
dMethod: argument tech 5
Exit:main|test/instrumentj/impl/SomeClass|dMethod|(Ljava/lang/String;I)V|177
Stateful exiting method: test/instrumentj/impl/SomeClass|dMethod|(Ljava/lang/String;I)V
```
